### PR TITLE
Rearrange entries in urdfs to comply with Pinocchio parsing logic

### DIFF
--- a/alexander-models/alexander_V1_description/urdf/alexander_v1.fullBody.urdf
+++ b/alexander-models/alexander_V1_description/urdf/alexander_v1.fullBody.urdf
@@ -1,34 +1,6 @@
 <?xml version = "1.0" ?>
 <robot name="Alexander">
 
-    <!-- NECK JOINTS -->
-    <joint name="NECK_Z" type="revolute">
-        <origin rpy="0 0 0" xyz="0.005 0 0.307953"/> <!-- placeholder for the joint location -->
-        <axis xyz="0 0 1"/>
-        <parent link="TORSO_LINK"/>
-        <child link="NECK_Z_LINK"/>
-        <limit effort="20" lower="-1.5708" upper="1.5708" velocity="20"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-    <joint name="NECK_Y" type="revolute">
-        <origin rpy="0 0 0" xyz="0.025 0.01 0.207252"/>
-        <axis xyz="0 1 0"/>
-        <parent link="NECK_Z_LINK"/>
-        <child link="HEAD_LINK"/>
-        <limit effort="20" lower="-1.0472" upper="1.0472" velocity="20"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
-    <!-- SPINE JOINTS -->
-    <joint name="SPINE_Z" type="revolute">
-        <origin rpy="0 0 0" xyz="0.0 0 0.018"/> <!-- check with CAD -->
-        <axis xyz="0 0 1"/>
-        <parent link="PELVIS_LINK"/>
-        <child link="TORSO_LINK"/>
-        <limit effort="150" lower="-0.5235987756" upper="0.5235987756" velocity="9.0"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <!-- LEFT LEG JOINTS -->
     <joint name="LEFT_HIP_X" type="revolute">
         <origin rpy="0 0 0" xyz="-0.162	0.0595	-0.015"/>
@@ -129,6 +101,149 @@
         <dynamics damping="0.05" friction="0.0"/>
     </joint>
 
+    <!-- SPINE JOINTS -->
+    <joint name="SPINE_Z" type="revolute">
+        <origin rpy="0 0 0" xyz="0.0 0 0.018"/> <!-- check with CAD -->
+        <axis xyz="0 0 1"/>
+        <parent link="PELVIS_LINK"/>
+        <child link="TORSO_LINK"/>
+        <limit effort="150" lower="-0.5235987756" upper="0.5235987756" velocity="9.0"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+
+    <!-- LEFT ARM JOINTS -->
+    <joint name="LEFT_SHOULDER_Y" type="revolute">
+        <origin xyz="-0.02 0.1 0.214" rpy="0.698132 0.0 0.0"/>
+        <axis xyz="0.0 1.0 0.0"/>
+        <parent link="TORSO_LINK"/>
+        <child link="LEFT_SHOULDER_Y_LINK"/>
+        <limit effort="150.0" lower="-3.141592" upper="1.22173" velocity="9.0"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+    <joint name="LEFT_SHOULDER_X" type="revolute">
+        <origin rpy="-0.698132 0.0 0.0" xyz="0.0 0.15676000 -0.01300000"/>
+        <axis xyz="1 0 0"/>
+        <parent link="LEFT_SHOULDER_Y_LINK"/>
+        <child link="LEFT_SHOULDER_X_LINK"/>
+        <limit effort="150.0" lower="-0.349066" upper="2.79253" velocity="9.0"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+    <joint name="LEFT_SHOULDER_Z" type="revolute">
+        <origin rpy="0.0 0.0 0.0" xyz="0.0 0.035 0.0"/>
+        <axis xyz="0.0 0.0 1.0"/>
+        <parent link="LEFT_SHOULDER_X_LINK"/>
+        <child link="LEFT_SHOULDER_Z_LINK"/>
+        <limit effort="80.0" lower="-1.91986" upper="1.22173" velocity="11.5"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+    <joint name="LEFT_ELBOW_Y" type="revolute">
+        <origin rpy="0.0 0.0 0.0" xyz="0.015 0.0 -0.3127"/>
+        <axis xyz="0.0 1.0 0.0"/>
+        <parent link="LEFT_SHOULDER_Z_LINK"/>
+        <child link="LEFT_ELBOW_Y_LINK"/>
+        <limit effort="80.0" lower="-2.35619" upper="0.174532925" velocity="11.5"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+    <joint name="LEFT_WRIST_Z" type="revolute">
+        <origin xyz="-0.015 0.0 0.0" rpy="0.0 0.0 0.0"/>
+        <axis xyz="0.0 0.0 1.0"/>
+        <parent link="LEFT_ELBOW_Y_LINK"/>
+        <child link="LEFT_WRIST_Z_LINK"/>
+        <limit effort="20.0" lower="-2.61799" upper="2.61799" velocity="25.0"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+    <joint name="LEFT_WRIST_X" type="revolute">
+        <origin xyz="0.0 -0.013 -0.25" rpy="0.0 0.0 0.0"/>
+        <axis xyz="1 0 0"/>
+        <parent link="LEFT_WRIST_Z_LINK"/>
+        <child link="LEFT_WRIST_X_LINK"/>
+        <limit effort="20.0" lower="-1.8326" upper="0.610865" velocity="25.0"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+    <joint name="LEFT_GRIPPER_Z" type="revolute">
+        <origin xyz="0.0 0.013 -0.031" rpy="0.0 0.0 0.0"/>
+        <axis xyz="0.0 0.0 1.0"/>
+        <parent link="LEFT_WRIST_X_LINK"/>
+        <child link="LEFT_GRIPPER_Z_LINK"/>
+        <limit effort="20.0" lower="-2.61799" upper="2.61799" velocity="25.0"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+
+    <!-- NECK JOINTS -->
+    <joint name="NECK_Z" type="revolute">
+        <origin rpy="0 0 0" xyz="0.005 0 0.307953"/> <!-- placeholder for the joint location -->
+        <axis xyz="0 0 1"/>
+        <parent link="TORSO_LINK"/>
+        <child link="NECK_Z_LINK"/>
+        <limit effort="20" lower="-1.5708" upper="1.5708" velocity="20"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+    <joint name="NECK_Y" type="revolute">
+        <origin rpy="0 0 0" xyz="0.025 0.01 0.207252"/>
+        <axis xyz="0 1 0"/>
+        <parent link="NECK_Z_LINK"/>
+        <child link="HEAD_LINK"/>
+        <limit effort="20" lower="-1.0472" upper="1.0472" velocity="20"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+
+    <!-- RIGHT ARM JOINTS -->
+    <joint name="RIGHT_SHOULDER_Y" type="revolute">
+        <origin xyz="-0.02 -0.1 0.214" rpy="-0.698132 0.0 0.0"/>
+        <axis xyz="0.0 1.0 0.0"/>
+        <parent link="TORSO_LINK"/>
+        <child link="RIGHT_SHOULDER_Y_LINK"/>
+        <limit effort="1000" lower="-3.141592" upper="1.22173" velocity="100"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+    <joint name="RIGHT_SHOULDER_X" type="revolute">
+        <origin rpy="0.698132 0.0 0.0" xyz="0.0 -0.15676000 -0.01300000"/>
+        <axis xyz="1 0 0"/>
+        <parent link="RIGHT_SHOULDER_Y_LINK"/>
+        <child link="RIGHT_SHOULDER_X_LINK"/>
+        <limit effort="1000" lower="-2.79253" upper="0.349066" velocity="100"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+    <joint name="RIGHT_SHOULDER_Z" type="revolute">
+        <origin rpy="0.0 0.0 0.0" xyz="0.0 -0.035 0.0"/>
+        <axis xyz="0.0 0.0 1.0"/>
+        <parent link="RIGHT_SHOULDER_X_LINK"/>
+        <child link="RIGHT_SHOULDER_Z_LINK"/>
+        <limit effort="1000" lower="-1.22173" upper="1.91986" velocity="100"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+    <joint name="RIGHT_ELBOW_Y" type="revolute">
+        <origin rpy="0.0 0.0 0.0" xyz="0.015 0.0 -0.3127"/>
+        <axis xyz="0.0 1.0 0.0"/>
+        <parent link="RIGHT_SHOULDER_Z_LINK"/>
+        <child link="RIGHT_ELBOW_Y_LINK"/>
+        <limit effort="1000" lower="-2.35619" upper="0.174532925" velocity="100"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+    <joint name="RIGHT_WRIST_Z" type="revolute">
+        <origin xyz="-0.015 0.0 0.0" rpy="0.0 0.0 0.0"/>
+        <axis xyz="0.0 0.0 1.0"/>
+        <parent link="RIGHT_ELBOW_Y_LINK"/>
+        <child link="RIGHT_WRIST_Z_LINK"/>
+        <limit effort="20.0" lower="-2.61799" upper="2.61799" velocity="25.0"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+    <joint name="RIGHT_WRIST_X" type="revolute">
+        <origin xyz="0.0 0.013 -0.25" rpy="0.0 0.0 0.0"/>
+        <axis xyz="1 0 0"/>
+        <parent link="RIGHT_WRIST_Z_LINK"/>
+        <child link="RIGHT_WRIST_X_LINK"/>
+        <limit effort="20.0" lower="-0.610865" upper="1.8326" velocity="25.0"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
+    <joint name="RIGHT_GRIPPER_Z" type="revolute">
+        <origin xyz="0.0 -0.013 -0.031" rpy="0.0 0.0 0.0"/>
+        <axis xyz="0.0 0.0 1.0"/>
+        <parent link="RIGHT_WRIST_X_LINK"/>
+        <child link="RIGHT_GRIPPER_Z_LINK"/>
+        <limit effort="20.0" lower="-2.61799" upper="2.61799" velocity="25.0"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
 
     <!-- LINKS -->
     <link name="PELVIS_LINK">
@@ -198,7 +313,7 @@
             <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
         </visual>
     </link>
-    
+
     <!-- LeftHipRollIMU-->
 	<link name="LEFT_HIP_X_IMU_LINK">
 		<inertial>
@@ -235,8 +350,7 @@
 			</imu>
 		</sensor>
 	</gazebo>
-    
-    
+
     <link name="LEFT_HIP_Z_LINK">
          <inertial>
              <mass value="0.77281362"/>
@@ -276,7 +390,7 @@
             <origin rpy="0.0 0.0 0.0" xyz="0 0 0"/>
         </visual>
     </link>
-    
+
     <!-- LeftThighIMU-->
     <link name="LEFT_THIGH_IMU_LINK">
         <inertial>
@@ -313,7 +427,7 @@
             </imu>
         </sensor>
     </gazebo>
-    
+
     <!-- LeftShinIMU-->
 	<link name="LEFT_SHIN_IMU_LINK">
 		<inertial>
@@ -351,7 +465,6 @@
 		</sensor>
 	</gazebo>
 
-    
     <link name="LEFT_ANKLE_Y_LINK">
         <inertial>
             <mass value="0.05045632"/>
@@ -378,7 +491,7 @@
             <origin rpy="0.0 0.0 0.0" xyz="0 0 0"/>
         </visual>
     </link>
-    
+
     <!-- LeftFootIMU-->
 	<link name="LEFT_FOOT_IMU_LINK">
 		<inertial>
@@ -415,7 +528,6 @@
 			</imu>
 		</sensor>
 	</gazebo>
-
 
     <!-- RIGHT LEG LINKS -->
     <link name="RIGHT_HIP_X_LINK">
@@ -584,7 +696,6 @@
 		</sensor>
 	</gazebo>
 
-
     <link name="RIGHT_ANKLE_Y_LINK">
         <inertial>
             <mass value="0.05045632"/>
@@ -697,15 +808,6 @@
 
 
     <!-- Left Arm -->
-    <joint name="LEFT_SHOULDER_Y" type="revolute">
-        <origin xyz="-0.02 0.1 0.214" rpy="0.698132 0.0 0.0"/>
-        <axis xyz="0.0 1.0 0.0"/>
-        <parent link="TORSO_LINK"/>
-        <child link="LEFT_SHOULDER_Y_LINK"/>
-        <limit effort="150.0" lower="-3.141592" upper="1.22173" velocity="9.0"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <link name="LEFT_SHOULDER_Y_LINK">
         <inertial>
             <mass value="2.99"/>
@@ -719,16 +821,6 @@
             <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
         </visual>
     </link>
-
-    <joint name="LEFT_SHOULDER_X" type="revolute">
-        <origin rpy="-0.698132 0.0 0.0" xyz="0.0 0.15676000 -0.01300000"/>
-        <axis xyz="1 0 0"/>
-        <parent link="LEFT_SHOULDER_Y_LINK"/>
-        <child link="LEFT_SHOULDER_X_LINK"/>
-        <limit effort="150.0" lower="-0.349066" upper="2.79253" velocity="9.0"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <link name="LEFT_SHOULDER_X_LINK">
         <inertial>
             <mass value="0.972"/>
@@ -742,16 +834,6 @@
             <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
         </visual>
     </link>
-
-    <joint name="LEFT_SHOULDER_Z" type="revolute">
-        <origin rpy="0.0 0.0 0.0" xyz="0.0 0.035 0.0"/>
-        <axis xyz="0.0 0.0 1.0"/>
-        <parent link="LEFT_SHOULDER_X_LINK"/>
-        <child link="LEFT_SHOULDER_Z_LINK"/>
-        <limit effort="80.0" lower="-1.91986" upper="1.22173" velocity="11.5"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <link name="LEFT_SHOULDER_Z_LINK">
         <inertial>
             <mass value="2.91"/>
@@ -765,16 +847,6 @@
             <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0867"/>
         </visual>
     </link>
-
-    <joint name="LEFT_ELBOW_Y" type="revolute">
-        <origin rpy="0.0 0.0 0.0" xyz="0.015 0.0 -0.3127"/>
-        <axis xyz="0.0 1.0 0.0"/>
-        <parent link="LEFT_SHOULDER_Z_LINK"/>
-        <child link="LEFT_ELBOW_Y_LINK"/>
-        <limit effort="80.0" lower="-2.35619" upper="0.174532925" velocity="11.5"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <link name="LEFT_ELBOW_Y_LINK">
         <inertial>
             <mass value="0.45"/>
@@ -788,16 +860,6 @@
             <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
         </visual>
     </link>
-
-    <joint name="LEFT_WRIST_Z" type="revolute">
-        <origin xyz="-0.015 0.0 0.0" rpy="0.0 0.0 0.0"/>
-        <axis xyz="0.0 0.0 1.0"/>
-        <parent link="LEFT_ELBOW_Y_LINK"/>
-        <child link="LEFT_WRIST_Z_LINK"/>
-        <limit effort="20.0" lower="-2.61799" upper="2.61799" velocity="25.0"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <link name="LEFT_WRIST_Z_LINK">
         <inertial>
             <mass value="1.547"/> <!-- This is a measured value. Refer to https://docs.google.com/spreadsheets/d/1VXWFJk3VJUsfkHrDaytB2INq94un1KytIOzcKJD0p44/edit?gid=0#gid=0  -->
@@ -811,16 +873,6 @@
             <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
         </visual>
     </link>
-
-    <joint name="LEFT_WRIST_X" type="revolute">
-        <origin xyz="0.0 -0.013 -0.25" rpy="0.0 0.0 0.0"/>
-        <axis xyz="1 0 0"/>
-        <parent link="LEFT_WRIST_Z_LINK"/>
-        <child link="LEFT_WRIST_X_LINK"/>
-        <limit effort="20.0" lower="-1.8326" upper="0.610865" velocity="25.0"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <link name="LEFT_WRIST_X_LINK">
         <inertial>
             <mass value="0.909"/> <!-- This is a measured value. Refer to https://docs.google.com/spreadsheets/d/1VXWFJk3VJUsfkHrDaytB2INq94un1KytIOzcKJD0p44/edit?gid=0#gid=0  -->
@@ -834,16 +886,6 @@
             <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
         </visual>
     </link>
-
-    <joint name="LEFT_GRIPPER_Z" type="revolute">
-        <origin xyz="0.0 0.013 -0.031" rpy="0.0 0.0 0.0"/>
-        <axis xyz="0.0 0.0 1.0"/>
-        <parent link="LEFT_WRIST_X_LINK"/>
-        <child link="LEFT_GRIPPER_Z_LINK"/>
-        <limit effort="20.0" lower="-2.61799" upper="2.61799" velocity="25.0"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <link name="LEFT_GRIPPER_Z_LINK">
         <inertial>
             <mass value="0.251"/>
@@ -860,17 +902,7 @@
         </visual>
     </link>
 
-
     <!-- Right Arm -->
-    <joint name="RIGHT_SHOULDER_Y" type="revolute">
-        <origin xyz="-0.02 -0.1 0.214" rpy="-0.698132 0.0 0.0"/>
-        <axis xyz="0.0 1.0 0.0"/>
-        <parent link="TORSO_LINK"/>
-        <child link="RIGHT_SHOULDER_Y_LINK"/>
-        <limit effort="1000" lower="-3.141592" upper="1.22173" velocity="100"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <link name="RIGHT_SHOULDER_Y_LINK">
         <inertial>
             <mass value="2.99"/>
@@ -884,16 +916,6 @@
             <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
         </visual>
     </link>
-
-    <joint name="RIGHT_SHOULDER_X" type="revolute">
-        <origin rpy="0.698132 0.0 0.0" xyz="0.0 -0.15676000 -0.01300000"/>
-        <axis xyz="1 0 0"/>
-        <parent link="RIGHT_SHOULDER_Y_LINK"/>
-        <child link="RIGHT_SHOULDER_X_LINK"/>
-        <limit effort="1000" lower="-2.79253" upper="0.349066" velocity="100"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <link name="RIGHT_SHOULDER_X_LINK">
         <inertial>
             <mass value="0.972"/>
@@ -907,16 +929,6 @@
             <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
         </visual>
     </link>
-
-    <joint name="RIGHT_SHOULDER_Z" type="revolute">
-        <origin rpy="0.0 0.0 0.0" xyz="0.0 -0.035 0.0"/>
-        <axis xyz="0.0 0.0 1.0"/>
-        <parent link="RIGHT_SHOULDER_X_LINK"/>
-        <child link="RIGHT_SHOULDER_Z_LINK"/>
-        <limit effort="1000" lower="-1.22173" upper="1.91986" velocity="100"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <link name="RIGHT_SHOULDER_Z_LINK">
         <inertial>
             <mass value="2.91"/>
@@ -930,16 +942,6 @@
             <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0867"/>
         </visual>
     </link>
-
-    <joint name="RIGHT_ELBOW_Y" type="revolute">
-        <origin rpy="0.0 0.0 0.0" xyz="0.015 0.0 -0.3127"/>
-        <axis xyz="0.0 1.0 0.0"/>
-        <parent link="RIGHT_SHOULDER_Z_LINK"/>
-        <child link="RIGHT_ELBOW_Y_LINK"/>
-        <limit effort="1000" lower="-2.35619" upper="0.174532925" velocity="100"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <link name="RIGHT_ELBOW_Y_LINK">
         <inertial>
             <mass value="0.45"/>
@@ -953,16 +955,6 @@
             <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
         </visual>
     </link>
-
-    <joint name="RIGHT_WRIST_Z" type="revolute">
-        <origin xyz="-0.015 0.0 0.0" rpy="0.0 0.0 0.0"/>
-        <axis xyz="0.0 0.0 1.0"/>
-        <parent link="RIGHT_ELBOW_Y_LINK"/>
-        <child link="RIGHT_WRIST_Z_LINK"/>
-        <limit effort="20.0" lower="-2.61799" upper="2.61799" velocity="25.0"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <link name="RIGHT_WRIST_Z_LINK">
         <inertial>
             <mass value="1.547"/> <!-- This is a measured value. Refer to https://docs.google.com/spreadsheets/d/1VXWFJk3VJUsfkHrDaytB2INq94un1KytIOzcKJD0p44/edit?gid=0#gid=0  -->
@@ -976,16 +968,6 @@
             <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
         </visual>
     </link>
-
-    <joint name="RIGHT_WRIST_X" type="revolute">
-        <origin xyz="0.0 0.013 -0.25" rpy="0.0 0.0 0.0"/>
-        <axis xyz="1 0 0"/>
-        <parent link="RIGHT_WRIST_Z_LINK"/>
-        <child link="RIGHT_WRIST_X_LINK"/>
-        <limit effort="20.0" lower="-0.610865" upper="1.8326" velocity="25.0"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <link name="RIGHT_WRIST_X_LINK">
         <inertial>
             <mass value="0.909"/> <!-- This is a measured value. Refer to https://docs.google.com/spreadsheets/d/1VXWFJk3VJUsfkHrDaytB2INq94un1KytIOzcKJD0p44/edit?gid=0#gid=0  -->
@@ -999,16 +981,6 @@
             <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
         </visual>
     </link>
-
-    <joint name="RIGHT_GRIPPER_Z" type="revolute">
-        <origin xyz="0.0 -0.013 -0.031" rpy="0.0 0.0 0.0"/>
-        <axis xyz="0.0 0.0 1.0"/>
-        <parent link="RIGHT_WRIST_X_LINK"/>
-        <child link="RIGHT_GRIPPER_Z_LINK"/>
-        <limit effort="20.0" lower="-2.61799" upper="2.61799" velocity="25.0"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <link name="RIGHT_GRIPPER_Z_LINK">
         <inertial>
             <mass value="0.251"/>

--- a/alexander-models/alexander_V1_description/urdf/alexander_v1.lowerBody.urdf
+++ b/alexander-models/alexander_V1_description/urdf/alexander_v1.lowerBody.urdf
@@ -1,16 +1,6 @@
 <?xml version = "1.0" ?>
 <robot name="Alexander">
 
-    <!-- SPINE JOINTS -->
-    <joint name="SPINE_Z" type="revolute">
-        <origin rpy="0 0 0" xyz="0.0 0 0.018"/> <!-- check with CAD -->
-        <axis xyz="0 0 1"/>
-        <parent link="PELVIS_LINK"/>
-        <child link="TORSO_LINK"/>
-        <limit effort="150" lower="-0.5235987756" upper="0.5235987756" velocity="9.0"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <!-- LEFT LEG JOINTS -->
     <joint name="LEFT_HIP_X" type="revolute">
         <origin rpy="0 0 0" xyz="-0.162	0.0595	-0.015"/>
@@ -111,6 +101,15 @@
         <dynamics damping="0.05" friction="0.0"/>
     </joint>
 
+    <!-- SPINE JOINTS -->
+    <joint name="SPINE_Z" type="revolute">
+        <origin rpy="0 0 0" xyz="0.0 0 0.018"/> <!-- check with CAD -->
+        <axis xyz="0 0 1"/>
+        <parent link="PELVIS_LINK"/>
+        <child link="TORSO_LINK"/>
+        <limit effort="150" lower="-0.5235987756" upper="0.5235987756" velocity="9.0"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
 
     <!-- LINKS -->
     <link name="PELVIS_LINK">

--- a/alexander-models/alexander_V1_description/urdf/alexander_v1.lowerBodyOnly.urdf
+++ b/alexander-models/alexander_V1_description/urdf/alexander_v1.lowerBodyOnly.urdf
@@ -1,16 +1,6 @@
 <?xml version = "1.0" ?>
 <robot name="Alexander">
 
-    <!-- SPINE JOINTS -->
-    <joint name="SPINE_Z" type="revolute">
-        <origin rpy="0 0 0" xyz="0.0 0 0.018"/> <!-- check with CAD -->
-        <axis xyz="0 0 1"/>
-        <parent link="PELVIS_LINK"/>
-        <child link="TORSO_LINK"/>
-        <limit effort="150" lower="-0.5235987756" upper="0.5235987756" velocity="9.0"/>
-        <dynamics damping="0.05" friction="0.0"/>
-    </joint>
-
     <!-- LEFT LEG JOINTS -->
     <joint name="LEFT_HIP_X" type="revolute">
         <origin rpy="0 0 0" xyz="-0.162	0.0595	-0.015"/>
@@ -111,6 +101,15 @@
         <dynamics damping="0.05" friction="0.0"/>
     </joint>
 
+    <!-- SPINE JOINTS -->
+    <joint name="SPINE_Z" type="revolute">
+        <origin rpy="0 0 0" xyz="0.0 0 0.018"/> <!-- check with CAD -->
+        <axis xyz="0 0 1"/>
+        <parent link="PELVIS_LINK"/>
+        <child link="TORSO_LINK"/>
+        <limit effort="150" lower="-0.5235987756" upper="0.5235987756" velocity="9.0"/>
+        <dynamics damping="0.05" friction="0.0"/>
+    </joint>
 
     <!-- LINKS -->
     <link name="PELVIS_LINK">


### PR DESCRIPTION
In MPC-land, so far we've lucked out in that we parse URDFs in the same fashion as Pinocchio (the rigid body dynamics lib used by MPC). That luck has run out with Alexander -- the joints are parsed in a different order, and a core part of the MPC API is passing over the state of the robot in a vector of doubles.

Unfortunately, pinocchio uses a third-party lib (urdfdom) to parse URDFs, and doesn't expose any APIs for varying the joint ordering, so we have limited control over how to change that. What I have done, is change how we parse our URDF Java-side by reordering the entries of the joints in the Alexander URDFs.

Let me know if this is satisfactory, as this gets my tests passing.
* I don't know much about how the URDFs are generated by us -- will this be overwritten if a new generate is done? I'm not too bothered if that happens infrequently.
* Otherwise, I can always copy-paste and make a separate MPC URDF suite, but that would add bloat to `AlexanderVersion`