### PR TITLE
Add missing alex_v2 EZ gripper adapter URDFs

### DIFF
--- a/alex-models/alex_V1_description/urdf/alex_v2.leftEZGripperAdapter.urdf
+++ b/alex-models/alex_V1_description/urdf/alex_v2.leftEZGripperAdapter.urdf
@@ -1,0 +1,9 @@
+<?xml version = "1.0" ?>
+<robot name="Alex">
+    <joint name="LEFT_EZGRIPPER_ADAPTER" type="fixed">
+        <!-- TODO: Figure out correct origin -->
+        <origin xyz="0 0 -0.02" rpy="3.141592 1.570796 0"/>
+        <parent link="LEFT_GRIPPER_Z_LINK"/>
+        <child link="left_ezgripper_palm_link"/>
+    </joint>
+</robot>

--- a/alex-models/alex_V1_description/urdf/alex_v2.rightEZGripperAdapter.urdf
+++ b/alex-models/alex_V1_description/urdf/alex_v2.rightEZGripperAdapter.urdf
@@ -1,0 +1,9 @@
+<?xml version = "1.0" ?>
+<robot name="Alex">
+    <joint name="RIGHT_EZGRIPPER_ADAPTER" type="fixed">
+        <!-- TODO: Figure out correct origin -->
+        <origin xyz="0 0 -0.02" rpy="3.141592 1.570796 0"/>
+        <parent link="RIGHT_GRIPPER_Z_LINK"/>
+        <child link="right_ezgripper_palm_link"/>
+    </joint>
+</robot>


### PR DESCRIPTION
## Summary
- Adds `alex_v2.leftEZGripperAdapter.urdf` and `alex_v2.rightEZGripperAdapter.urdf` under `alex-models/alex_V1_description/urdf/`
- Fixes 24 failing `alex` controller API tests that load `AlexV1Version.FULL_ROBOT_EZGRIPPERS` after PR #327 changed `AlexV1Version` to use the `alex_v2.` iteration prefix

## Context
`AlexURDFParameters` resolves adapter paths as `alex_V1_description/urdf/alex_v2.leftEZGripperAdapter.urdf`, but only v1-prefixed EZ gripper adapter files existed. Other v2 body/ability-hand URDFs were already present; EZ gripper adapters were the gap.

## Test plan
- [x] `gradle build` in `ihmc-alex-sdk` — new URDFs packaged in jar
- [x] `gradle test -PtestTags=fast --tests us.ihmc.alex.controllerAPI.AlexEndToEndHandTrajectoryMessageTest` in `alex` — URDF loads without `Unable to open robot model file` error
- [ ] Merge and confirm `alex` CI controller-api / fast jobs pass


Made with [Cursor](https://cursor.com)